### PR TITLE
Remove eval-when-compile

### DIFF
--- a/toggle-test.el
+++ b/toggle-test.el
@@ -36,7 +36,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl)
 
 (defgroup toggle-test nil
   "IntelliJ like facility to quickly toggle between source and its corresponding test files."
@@ -256,5 +256,9 @@ One entry per project that provides naming convention and folder structure"
 	      (string= (substring file-name 0 (length dir-name)) dir-name))) 'nil))
 
 (provide 'toggle-test)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
 
 ;;; toggle-test.el ends here


### PR DESCRIPTION
Because this file uses some cl-functions. We can use eval-when-compile
if file uses only cl macros. And suppress byte compile warning for
use cl-functions.
