### PR TITLE
Fix byte compile warnings

### DIFF
--- a/toggle-test.el
+++ b/toggle-test.el
@@ -108,8 +108,8 @@ One entry per project that provides naming convention and folder structure"
   (length (split-string (file-name-as-directory (tgt-root-dir proj)) "/")))
 
 (defun tgt-find-project-file-in-dirs (file proj)
-  (assert (tgt-proj-prop :src-dirs proj) 'nil "Source directory not configured")
-  (assert (tgt-proj-prop :test-dirs proj) 'nil "Test directory not configured")
+  (assert (tgt-proj-prop :src-dirs proj) nil "Source directory not configured")
+  (assert (tgt-proj-prop :test-dirs proj) nil "Test directory not configured")
   (let ((src-file-rel-path (tgt-relative-file-path file proj :src-dirs)))
     (if src-file-rel-path 
 	(values src-file-rel-path 'nil)


### PR DESCRIPTION
formatting error is raised if `nil` is quoted.
I got following error with original code when byte-compile.

```
In tgt-find-project-file-in-dirs:
toggle-test.el:112:37:Warning: `error' called with 1 args to fill 0 format
    field(s)
toggle-test.el:116:49:Warning: `error' called with 1 args to fill 0 format
    field(s)
```
